### PR TITLE
更新 hypertrons 配置文件

### DIFF
--- a/.github/hypertrons.json
+++ b/.github/hypertrons.json
@@ -67,19 +67,19 @@
         {
           "name": "committer",
           "description": "Committer of the project",
-          "users": [ "leofang", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666" ],
+          "users": [ "leofang327", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666" ],
           "commands": [ "/difficulty", "/rerun", "/complete-checklist", "/start-vote" ]
         },
         {
           "name": "replier",
           "description": "Replier is responsible for reply issues in time",
-          "users": [ "leofang", "heming6666" ],
+          "users": [ "leofang327", "heming6666" ],
           "commands": []
         },
         {
           "name": "approver",
           "description": "After approvers' approve, pulls should be merged automatically",
-          "users": [ "leofang", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666"  ],
+          "users": [ "leofang327", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666"  ],
           "commands": [ "/approve" ]
         },
         {

--- a/.github/hypertrons.json
+++ b/.github/hypertrons.json
@@ -67,19 +67,19 @@
         {
           "name": "committer",
           "description": "Committer of the project",
-          "users": [ "LiuChangFreeman", "WuShaoling" ],
+          "users": [ "leofang", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666" ],
           "commands": [ "/difficulty", "/rerun", "/complete-checklist", "/start-vote" ]
         },
         {
           "name": "replier",
           "description": "Replier is responsible for reply issues in time",
-          "users": [ "LiuChangFreeman", "WuShaoling" ],
+          "users": [ "leofang", "heming6666" ],
           "commands": []
         },
         {
           "name": "approver",
           "description": "After approvers' approve, pulls should be merged automatically",
-          "users": [ "LiuChangFreeman", "WuShaoling" ],
+          "users": [ "leofang", "WuShaoling", "frank-zsy", "will-ww", "Jerry", "heming6666"  ],
           "commands": [ "/approve" ]
         },
         {


### PR DESCRIPTION
Related #2.

### Changes
- 移动 `hypertrons.json` 文件位置到 `.github` 目录下。
- 相关配置及插件配置可查看 `hypertrons.json` 文件.

Signed-off-by: LinHaiming <lhming23@outlook.com>